### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,5 +1,8 @@
 name: Django CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/badreddine023/phi-chain/security/code-scanning/2](https://github.com/badreddine023/phi-chain/security/code-scanning/2)

In general, the fix is to explicitly declare `permissions` for the workflow or individual jobs so that the `GITHUB_TOKEN` has only the minimal scopes required. For this Django CI workflow, the steps only need to read the repository contents to run tests, so we can safely set `contents: read` at the workflow level (or at the job level) without impacting functionality.

The best minimal fix here is to add a root-level `permissions:` block just after the `name:` (before `on:`). This applies to all jobs that do not override permissions, which includes the single `build` job shown. Specifically, in `.github/workflows/django.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Django CI`) and line 3 (`on:`). No additional imports, methods, or other definitions are needed, as this is purely a configuration change within the workflow file. This will satisfy CodeQL’s requirement and enforce least-privilege access for the `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
