### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,5 +1,8 @@
 name: Pylint
 
+permissions:
+  contents: read
+
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/badreddine023/phi-chain/security/code-scanning/1](https://github.com/badreddine023/phi-chain/security/code-scanning/1)

To fix the problem, we should explicitly define a restrictive `permissions:` block in the workflow so that the `GITHUB_TOKEN` is limited to the minimal access needed. Since this workflow only checks out code and runs `pylint`, it does not need to write anything back to GitHub and typically only requires `contents: read`, or can even disable the token entirely with `permissions: {}`. Using `contents: read` is a safe, standard minimal configuration that satisfies CodeQL’s recommendation.

The best fix without changing existing functionality is to add a `permissions:` block at the top workflow level, just under the `name` (or under `on:`) so it applies to all jobs, including `build`. We do not need any imports or additional definitions since this is YAML configuration. Concretely, in `.github/workflows/pylint.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: Pylint` line (or after `on: [push]`; either is valid). No other lines in the existing job definition need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
